### PR TITLE
Don't emit warnings in tests

### DIFF
--- a/lib/forewarn/config.rb
+++ b/lib/forewarn/config.rb
@@ -11,10 +11,13 @@ module Forewarn
     :warners => [Forewarn::Warners::StringMutation]
   }.freeze
 
-  @__config = DEFAULT_CONFIG.dup
-
   def self.config(overrides = {})
     @__config.merge!(overrides)
   end
+
+  def self.reset_config
+    @__config = DEFAULT_CONFIG.dup
+  end
+  reset_config
 end
 

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -7,13 +7,34 @@ require 'gimme'
 require 'pry'
 
 class ForewarnTest < Minitest::Test
+  def forewarn_logger
+    @logger ||= ForewarnLogger.new
+  end
+
+  def forewarn_test_config
+    { enabled: true,
+      logger:  forewarn_logger,
+      warners: [],
+    }
+  end
+
   def after_teardown
     Gimme.reset
-    Forewarn.config(Forewarn::DEFAULT_CONFIG)
+    Forewarn.config(forewarn_test_config)
   end
 
   def regex(regex_input)
     RegexMatcher.new(regex_input)
+  end
+end
+
+class ForewarnLogger
+  def call(*args)
+    logged << args
+  end
+
+  def logged
+    @logged ||= []
   end
 end
 

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -11,6 +11,10 @@ class ForewarnTest < Minitest::Test
     Gimme.reset
     Forewarn.config(Forewarn::DEFAULT_CONFIG)
   end
+
+  def regex(regex_input)
+    RegexMatcher.new(regex_input)
+  end
 end
 
 class RegexMatcher
@@ -22,8 +26,3 @@ class RegexMatcher
     arg =~ @regex_input
   end
 end
-def regex(regex_input)
-  RegexMatcher.new(regex_input)
-end
-
-

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -1,16 +1,21 @@
 require 'minitest_helper'
 
 class TestConfig < ForewarnTest
-  def test_defaults
-    assert_equal Forewarn::DEFAULT_CONFIG, Forewarn.config
-    assert Forewarn::DEFAULT_CONFIG.frozen?
+  def test_defaults_are_frozen
+    assert_predicate Forewarn::DEFAULT_CONFIG, :frozen?
   end
 
-  def test_overwrite_an_option
-    result = Forewarn.config(:enabled => false)
+  def test_overwriting_an_option_persists_the_change
+    keys       = Forewarn.config.keys
+    initial    = Forewarn.config[:enabled]
+    overridden = !initial
 
-    assert_equal Forewarn::DEFAULT_CONFIG.merge(:enabled => false), result
-    assert_equal Forewarn.config, result, "change is persisted"
-    assert_equal Forewarn::DEFAULT_CONFIG[:enabled], true, "default is same"
+    begin
+      Forewarn.config(:enabled => overridden)
+      assert_equal Forewarn.config[:enabled], overridden
+      assert_equal Forewarn.config.keys, keys
+    ensure
+      Forewarn.config(:enabled => initial)
+    end
   end
 end

--- a/test/test_forewarn.rb
+++ b/test/test_forewarn.rb
@@ -26,7 +26,8 @@ class TestForewarn
     end
 
     def test_integrated_thing_works
-      String some_string = "WOOO"
+      Forewarn.config[:warners] << Forewarn::Warners::StringMutation
+      some_string = "WOOO"
 
       Forewarn.start!
       some_string << "P"

--- a/test/test_overrides_methods.rb
+++ b/test/test_overrides_methods.rb
@@ -3,7 +3,6 @@ require "minitest_helper"
 class TestOverridesMethods < ForewarnTest
   def setup
     @triggers_warning = gimme_next(Forewarn::TriggersWarning)
-
     @subject = Forewarn::OverridesMethods.new
   end
 
@@ -12,6 +11,7 @@ class TestOverridesMethods < ForewarnTest
       :yelp
     end
   end
+
   class Cat < Animal
     def meow
     end
@@ -22,8 +22,9 @@ class TestOverridesMethods < ForewarnTest
 
     @subject.override!([method])
     Cat.new.make_noise
+    called_from = __LINE__ - 1
 
-    verify(@triggers_warning).trigger!(method, regex(/.*forewarn\/test\/test_overrides_methods.rb:24:in `test_trigger'/))
+    verify(@triggers_warning).trigger!(method, regex(/.*forewarn\/test\/test_overrides_methods.rb:#{called_from}:in `#{__method__}'/))
   end
 
   def test_skip_trigger_on_broader_receiver_type


### PR DESCRIPTION
Was looking at the tests b/c I saw that [CI was failing](https://travis-ci.org/testdouble/forewarn/builds/77604554). Couldn't figure out how to set the seed to continue failing and finally decided to just run it with [mrspec](https://rubygems.org/gems/mrspec), but that emitted tons of warnings that were previously not seen due to running through rake. So I made some changes to fix this, and it turns out that the same changes also fixed the intermittent failure... I guess that's PR worthy.
## Before

![before](https://s3.amazonaws.com/josh.cheek/images/scratch/forewarn-before.png)
## After

![after](https://s3.amazonaws.com/josh.cheek/images/scratch/forewarn-after.png)
